### PR TITLE
Change the SecureConfigurationLoader 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+#generated files
+/target/
+
+#Project conf and preferences files
+/.idea/
+/secure-file-upload.iml

--- a/src/main/java/com/juanjolmm/security/impl/service/AbstractSecureFileUploader.java
+++ b/src/main/java/com/juanjolmm/security/impl/service/AbstractSecureFileUploader.java
@@ -36,7 +36,15 @@ public abstract class AbstractSecureFileUploader implements SecureFileUploader {
 	 * Default constructor.
 	 */
 	public AbstractSecureFileUploader() {
-		SecureConfigurationLoader configLoader = new SecureConfigurationLoaderImpl();
+		this(new SecureConfigurationLoaderImpl());
+	}
+
+	/**
+	 * Constructor with custom configLoader
+	 *
+	 * @param configLoader an implementation of SecureConfigurationLoader
+	 */
+	public AbstractSecureFileUploader(SecureConfigurationLoader configLoader) {
 		requestOperator = new SecureRequestOperatorImpl(configLoader);
 		fileOperator = new SecureFileOperatorImpl(configLoader);
 	}

--- a/src/main/java/com/juanjolmm/security/impl/service/SecureFileUploaderInMemory.java
+++ b/src/main/java/com/juanjolmm/security/impl/service/SecureFileUploaderInMemory.java
@@ -6,6 +6,7 @@ import java.io.InputStream;
 
 import javax.annotation.Nonnull;
 
+import com.juanjolmm.security.api.operator.SecureConfigurationLoader;
 import com.juanjolmm.security.api.qualifiers.InMemory;
 import com.juanjolmm.security.exception.SecureFileUploadException;
 import com.juanjolmm.security.impl.util.SecureFileUtils;
@@ -27,6 +28,15 @@ public final class SecureFileUploaderInMemory extends AbstractSecureFileUploader
 	 */
 	public SecureFileUploaderInMemory() {
 		super();
+	}
+
+	/**
+	 * Constructor with custom configLoader
+	 *
+	 * @param configLoader an implementation of SecureConfigurationLoader
+	 */
+	public SecureFileUploaderInMemory(SecureConfigurationLoader configLoader) {
+		super(configLoader);
 	}
 
 	@Override

--- a/src/main/java/com/juanjolmm/security/impl/service/SecureFileUploaderStored.java
+++ b/src/main/java/com/juanjolmm/security/impl/service/SecureFileUploaderStored.java
@@ -7,6 +7,7 @@ import java.io.InputStream;
 
 import javax.annotation.Nonnull;
 
+import com.juanjolmm.security.api.operator.SecureConfigurationLoader;
 import org.apache.commons.io.FileUtils;
 
 import com.juanjolmm.security.api.qualifiers.Stored;
@@ -29,6 +30,15 @@ public final class SecureFileUploaderStored extends AbstractSecureFileUploader {
 	 */
 	public SecureFileUploaderStored() {
 		super();
+	}
+
+	/**
+	 * Constructor with custom configLoader
+	 *
+	 * @param configLoader an implementation of SecureConfigurationLoader
+	 */
+	public SecureFileUploaderStored(SecureConfigurationLoader configLoader) {
+		super(configLoader);
 	}
 
 	@Override


### PR DESCRIPTION
Your project is realy great ! Thanks for your work.

I just suggest to leave option of using different implementation for loading properties.
Others loader can implement more feature (system properties, env properties, reload properties, ...) like Apache-Commons-Configuration or Spring

I think some properties like `default.storage.folder` can depend on env/system variables 
like -> `${java.io.tmpdir}` or `${SECURE_DIR_PATH}`
It's not possible to manage property variables without modifying the loader implementation